### PR TITLE
Expose device/bluetooth names for android

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.classpath
 /.project
+/.vscode
 /libs
 /bin

--- a/README.md
+++ b/README.md
@@ -20,19 +20,40 @@ cordova plugin add cordova-plugin-device-name
 ```javascript
 var deviceName = cordova.plugins.deviceName;
 
-console.log(deviceName.name) // e.g: Becvert's iPad
+// on iOS
+console.log(deviceName.name) // e.g: "Becvert's iPad"
+console.log(deviceName.bluetoothName) // e.g: null
+console.log(deviceName.deviceName) // e.g: "Becvert's iPad"
 
-deviceName.get(function success(name) {
-    console.log(name);
+// on Android
+console.log(deviceName.name) // e.g: "HUAWEI P20 lite"
+console.log(deviceName.bluetoothName) // e.g: "HUAWEI P20 lite"
+console.log(deviceName.deviceName) // e.g: "ANE-LX1"
+
+deviceName.get(function success(names) {
+    console.log(names.name);
 }, function failure(error) {
     console.log(error);
 });
 ```
 
-if you installed cordova-plugin-device you can use:
+On Android, you'll get additional names you can choose from: `deviceName` and `bluetoothName`.
+`bluetoothName` is the user-defined name for the device which is often preferable to `deviceName`
+which is often just the model codename of the device.
+
+On Android, `name` defaults to `bluetoothName`, if available.
+
+If you installed cordova-plugin-device you can use:
 
 ```javascript
 window.device.name
+```
+
+You can access `deviceName` and `bluetoothName` from cordova-plugin-device on Android like this:
+
+```javascript
+window.device.otherNames.deviceName
+window.device.otherNames.bluetoothName
 ```
 
 ## Credits

--- a/src/android/net/becvert/cordova/DeviceName.java
+++ b/src/android/net/becvert/cordova/DeviceName.java
@@ -38,7 +38,7 @@ public class DeviceName extends CordovaPlugin {
 
         // set bluetoothName
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) { // 31    
-            bluetoothName = Settings.Global.getString(mContext.contentResolver, Settings.Global.DEVICE_NAME);
+            bluetoothName = Settings.Global.getString(cordova.getActivity().getContentResolver(), Settings.Global.DEVICE_NAME);
             name = bluetoothName;
             Log.d(TAG, "bluetooth_name " + name);
         } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) { // 24

--- a/src/android/net/becvert/cordova/DeviceName.java
+++ b/src/android/net/becvert/cordova/DeviceName.java
@@ -36,18 +36,15 @@ public class DeviceName extends CordovaPlugin {
         String bluetoothName = null;
         String deviceName = null;
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+        // set bluetoothName
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) { // 31    
+            bluetoothName = Settings.Global.getString(mContext.contentResolver, Settings.Global.DEVICE_NAME)
+            name = bluetoothName;
+            Log.d(TAG, "bluetooth_name " + name);
+        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) { // 24
             bluetoothName = Settings.Secure.getString(cordova.getActivity().getContentResolver(), "bluetooth_name");
             name = bluetoothName;
             Log.d(TAG, "bluetooth_name " + name);
-
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-                deviceName = Settings.Global.getString(cordova.getActivity().getContentResolver(), "device_name");
-                if (name == null) {
-                    name = deviceName;
-                }
-                Log.d(TAG, "device_name " + name);
-            }
         } else {
             BluetoothAdapter mBluetoothAdapter = BluetoothAdapter.getDefaultAdapter();
             if (mBluetoothAdapter != null) {
@@ -55,6 +52,15 @@ public class DeviceName extends CordovaPlugin {
                 name = bluetoothName;
                 Log.d(TAG, "bluetooth adapter " + name);
             }
+        }
+
+        // set deviceName
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) { // 24
+            deviceName = Settings.Global.getString(cordova.getActivity().getContentResolver(), "device_name");
+            if (name == null) {
+                name = deviceName;
+            }
+            Log.d(TAG, "device_name " + name);
         }
 
         JSONObject names = new JSONObject();

--- a/src/android/net/becvert/cordova/DeviceName.java
+++ b/src/android/net/becvert/cordova/DeviceName.java
@@ -38,7 +38,7 @@ public class DeviceName extends CordovaPlugin {
 
         // set bluetoothName
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) { // 31    
-            bluetoothName = Settings.Global.getString(mContext.contentResolver, Settings.Global.DEVICE_NAME)
+            bluetoothName = Settings.Global.getString(mContext.contentResolver, Settings.Global.DEVICE_NAME);
             name = bluetoothName;
             Log.d(TAG, "bluetooth_name " + name);
         } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) { // 24


### PR DESCRIPTION
On Android, there are 2 device names available: the one already exposed by this plugin and `bluetoothName` with is a user-chosen name for his device. This PR exposes the Android's `bluetoothName` to cordova.

**This PR constitutes a breaking change.**